### PR TITLE
Improve documentation

### DIFF
--- a/backend/lib/app/getTests.js
+++ b/backend/lib/app/getTests.js
@@ -5,7 +5,7 @@ import * as informativeTests from '../../../csaf-validator-lib/informativeTests.
 
 const swaggerInfo = {
   description:
-    'This endpoint is intended to be used to discover all available tests.',
+    'This endpoint is intended to be used to discover all available tests. For each tests it lists the name as well as the preset the test belongs to.',
   summary: 'Retrieve all tests.',
 }
 

--- a/backend/lib/app/validate.js
+++ b/backend/lib/app/validate.js
@@ -30,7 +30,7 @@ const presets = {
 
 const swaggerInfo = {
   description:
-    'This endpoint is intended to validate a document against the specified tests.',
+    'This endpoint is intended to validate a document against the specified tests. In the list of tests you need to provide at least one dict, where each dict is used to run either a single test or an entire preset. For \'name\' provide the test\'s or the preset\'s name, and as \'type\' provide either \'test\' or \'preset\'. For the value of the document-property just provide the json of your CSAF document.',
   summary: 'Validate document.',
 }
 

--- a/backend/lib/app/validate.js
+++ b/backend/lib/app/validate.js
@@ -30,7 +30,7 @@ const presets = {
 
 const swaggerInfo = {
   description:
-    'This endpoint is intended to validate a document against the specified tests. In the list of tests you need to provide at least one dict, where each dict is used to run either a single test or an entire preset. For \'name\' provide the test\'s or the preset\'s name, and as \'type\' provide either \'test\' or \'preset\'. For the value of the document-property just provide the json of your CSAF document.',
+    'This endpoint is intended to validate a document against the specified tests. In the list of tests provide at least one object, where each object is used to run either a single test or an entire preset. For \'name\' provide the test\'s or the preset\'s name, and as \'type\' provide accordingly either \'test\' or \'preset\'. For the value of the property \'document\' just provide the json of your CSAF document.',
   summary: 'Validate document.',
 }
 


### PR DESCRIPTION
When using the API first it was not clear at all how to use it. Here is a proposal that tries to improve the documentation.

I've seen both of the modified strings to also be part of index.adoc and generated/html/index.html. These should be potentially updated accordingly (or let me know how to do it)