### PR TITLE
chore: add missing .gitmodules top-level to fix `git clone --recursive-submodules`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "csaf-validator-lib/csaf"]
+	path = csaf-validator-lib/csaf
+	url = https://github.com/oasis-tcs/csaf.git


### PR DESCRIPTION
fixes secvisogram/csaf-validator-service#51

From what I've read, this is the best way to fix the issue. Please review.