### PR TITLE
Dependency updates

### DIFF
--- a/csaf-validator-lib/package-lock.json
+++ b/csaf-validator-lib/package-lock.json
@@ -16,7 +16,7 @@
         "json-pointer": "^0.6.1",
         "lodash": "^4.17.21",
         "packageurl-js": "^1.0.2",
-        "semver": "^7.3.8",
+        "semver": "^7.5.0",
         "undici": "^5.21.2"
       },
       "devDependencies": {
@@ -33,7 +33,7 @@
         "mocha": "^10.2.0",
         "prettier": "^2.8.1",
         "typescript": "^4.9.4",
-        "xml2js": "^0.4.23"
+        "xml2js": "^0.5.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -1246,9 +1246,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1501,9 +1501,9 @@
       "dev": true
     },
     "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dev": true,
       "dependencies": {
         "sax": ">=0.6.0",

--- a/csaf-validator-lib/package.json
+++ b/csaf-validator-lib/package.json
@@ -19,7 +19,7 @@
     "json-pointer": "^0.6.1",
     "lodash": "^4.17.21",
     "packageurl-js": "^1.0.2",
-    "semver": "^7.3.8",
+    "semver": "^7.5.0",
     "undici": "^5.21.2"
   },
   "devDependencies": {
@@ -36,7 +36,7 @@
     "mocha": "^10.2.0",
     "prettier": "^2.8.1",
     "typescript": "^4.9.4",
-    "xml2js": "^0.4.23"
+    "xml2js": "^0.5.0"
   },
   "version": "1.3.0"
 }


### PR DESCRIPTION
Update of csaf-validator-lib:
Update xml2js from 0.4.23 to 0.5.0 in /csaf-validator-lib
Update semver from 7.3.8 to 7.5.0 in /csaf-validator-lib