### PR TITLE
Add basic CORS functionality to support testing (WIP)

### DIFF
--- a/backend/lib/app.js
+++ b/backend/lib/app.js
@@ -40,4 +40,7 @@ export default async function (fastify) {
       )
     }
   )
+  fastify.register(import('@fastify/cors'), {
+    // customize here
+  })
 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "backend",
       "dependencies": {
+        "@fastify/cors": "^7.0.0",
         "close-with-grace": "^1.1.0",
         "config": "^3.3.8",
         "fastify": "^3.29.4",
@@ -50,6 +51,15 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/@fastify/cors": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-7.0.0.tgz",
+      "integrity": "sha512-nlo6ScwagBNJacAZD3KX90xjWLIoV0vN9QqoX1wUE9ZeZMdvkVkMZCGlxEtr00NshV0X5wDge4w5rwox7rRzSg==",
+      "dependencies": {
+        "fastify-plugin": "^3.0.0",
+        "vary": "^1.1.2"
+      }
     },
     "node_modules/@fastify/error": {
       "version": "2.0.0",
@@ -1833,6 +1843,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/workerpool": {
       "version": "6.2.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "dev": "nodemon -w \"*.js\" -w \"lib/**/*\" server.js"
   },
   "dependencies": {
+    "@fastify/cors": "^7.0.0",
     "close-with-grace": "^1.1.0",
     "config": "^3.3.8",
     "fastify": "^3.29.4",

--- a/backend/tests/api.js
+++ b/backend/tests/api.js
@@ -71,6 +71,40 @@ describe('API', function () {
     })
   })
 
+  describe('OPTIONS /api/v1/tests', function () {
+    it('returns valid CORS information', async function () {
+          const res = await request(
+            'http://localhost:' + getConfig().port + '/api/v1/tests',
+            {
+              method: 'OPTIONS',
+              headers: {
+                'Origin': 'http://localhost',
+                'Access-Control-Request-Method': 'GET',
+                'Access-Control-Request-Headers': 'content-type'
+              }
+            }
+          )
+          expect(res.statusCode).to.equal(204)
+    })
+  })
+
+  describe('OPTIONS /api/v1/validate', function () {
+    it('returns valid CORS information', async function () {
+          const res = await request(
+            'http://localhost:' + getConfig().port + '/api/v1/validate',
+            {
+              method: 'OPTIONS',
+              headers: {
+                'Origin': 'http://localhost',
+                'Access-Control-Request-Method': 'POST',
+                'Access-Control-Request-Headers': 'content-type'
+              }
+            }
+          )
+          expect(res.statusCode).to.equal(204)
+    })
+  })
+
   describe('POST /api/v1/validate', function () {
     describe('documents can be checked using presets and single tests', function () {
       for (let i = 0; i < getValidSampleDocuments().length; ++i) {


### PR DESCRIPTION
Added basic CORS funcationality by adding fastify-cors.
Allow localhost to access, this fits the most basic test setup.

See Issue #57