### PR TITLE
feat: add workflow to publish npm package on release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,33 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: NPM Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NPM_TOKEN: ${{secrets.npm_token}}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+@secvisogram:registry=https://registry.npmjs.org/
+always-auth=true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "csaf-validator-service",
-  "private": true,
+  "name": "@secvisogram/csaf-validator-service",
   "type": "module",
   "scripts": {
     "start": "cd backend && npm start",
@@ -15,6 +14,14 @@
     "prepare": "husky install",
     "process-readme": "markdown-toc -i README.md && prettier --write README.md && git add README.md",
     "dist": "./scripts/dist.sh"
+  },
+  "keywords": [
+    "csaf",
+    "csaf-validator-service",
+    "secvisogram"
+  ],
+  "publishConfig": {
+    "access": "public"
   },
   "devDependencies": {
     "husky": "^7.0.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   },
   "keywords": [
     "csaf",
+    "csaf full validator",
+    "csaf extended validator",
+    "csaf basic validator",
     "csaf-validator-service",
     "secvisogram"
   ],


### PR DESCRIPTION
# Changes
- Added github workflow to publish [npm package](https://www.npmjs.com/package/@secvisogram/csaf-validator-service) on every release.
- Created a [name reservation package](https://www.npmjs.com/package/csaf-validator-service).

# TODO
In order to make this work a new githubaction-secret with the name `npm_token` must be created.