### PR TITLE
fix: npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,10 +16,13 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
-      - run: |
-          npm run start &
-          sleep 3 &&
-          npm test
+      - run: npm start &
+      - uses: ifaxity/wait-on-action@v1.1.0
+        with:
+          delay: 1
+          timeout: 30000
+          resource: tcp:localhost:8082
+      - run: npm run test
 
   publish-npm:
     needs: build

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,10 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
-      - run: npm test
+      - run: |
+          npm run start &
+          sleep 3 &&
+          npm test
 
   publish-npm:
     needs: build


### PR DESCRIPTION
Fixes the npm-publish workflow

# Problem
Currently the npm publish fails because the tests return with errors.
This is because the workflow didn't start the service before testing.
The suggested change should fix that.